### PR TITLE
Migrate backend to Render

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -2,3 +2,4 @@ PORT=5000
 MONGODB_URI=mongodb+srv://codebyced:Nevastop2$@mysitecluster.du981.mongodb.net/?retryWrites=true&w=majority&appName=MySiteCluster
 NODE_ENV=development
 CLIENT_URL=http://localhost:3000
+ALLOWED_ORIGINS=http://localhost:3000,https://codebyced.com,https://codebyced.onrender.com

--- a/backend/.env
+++ b/backend/.env
@@ -1,5 +1,5 @@
 PORT=5000
 MONGODB_URI=mongodb+srv://codebyced:Nevastop2$@mysitecluster.du981.mongodb.net/?retryWrites=true&w=majority&appName=MySiteCluster
-NODE_ENV=development
-CLIENT_URL=http://localhost:3000
-ALLOWED_ORIGINS=http://localhost:3000,https://codebyced.com,https://codebyced.onrender.com
+NODE_ENV=production
+CLIENT_URL=https://codebyced.onrender.com
+ALLOWED_ORIGINS=https://codebyced.com,https://codebyced.onrender.com

--- a/backend/.env.render.example
+++ b/backend/.env.render.example
@@ -1,0 +1,5 @@
+PORT=5000
+MONGODB_URI=your-mongodb-uri
+NODE_ENV=production
+CLIENT_URL=https://codebyced.onrender.com
+ALLOWED_ORIGINS=https://codebyced.com,https://codebyced.onrender.com

--- a/backend/app.js
+++ b/backend/app.js
@@ -21,13 +21,20 @@ dotenv.config();
 const app = express();
 
 // Middleware
+const defaultOrigins = [
+  'http://localhost:3000',
+  'https://codebyced.com',
+  'https://codebyced.onrender.com',
+  'https://*.elevenlabs.io',
+  'https://elevenlabs.io'
+];
+
+const allowedOrigins = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(',').map(o => o.trim())
+  : defaultOrigins;
+
 app.use(cors({
-  origin: [
-    'http://localhost:3000',
-    'https://codebyced.com',
-    'https://*.elevenlabs.io',
-    'https://elevenlabs.io'
-  ],
+  origin: allowedOrigins,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With'],
   exposedHeaders: ['Content-Range', 'X-Content-Range'],
@@ -83,4 +90,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = app;
+module.exports = app

--- a/frontend/.env.render.example
+++ b/frontend/.env.render.example
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=https://codebyced.onrender.com/api

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "react-router-dom": "^6.30.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
+    "@tailwindcss/typography": "^0.5.9"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,7 +16,7 @@
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.30.0",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
     "@tailwindcss/typography": "^0.5.9"
   },
   "scripts": {

--- a/frontend/src/pages/ToolsPage.jsx
+++ b/frontend/src/pages/ToolsPage.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { Helmet } from 'react-helmet';
 import PageLayout from '../components/PageLayout';
+import { getApiUrl } from '../utils/api';
 
 const ToolsPage = () => {
   const [tools, setTools] = useState([]);
@@ -26,7 +27,7 @@ const ToolsPage = () => {
     const fetchTools = async () => {
       setIsLoading(true);
       try {
-        const response = await fetch('https://codebyced-production.up.railway.app/api/tools');
+        const response = await fetch(getApiUrl('/tools'));
         
         if (!response.ok) {
           throw new Error(`API error: ${response.status}`);
@@ -240,4 +241,4 @@ const ToolsPage = () => {
   );
 };
 
-export default ToolsPage;
+export default ToolsPage

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 // Use environment variable for API URL with production fallback
-const API_URL = process.env.REACT_APP_API_URL || 'https://codebyced-production.up.railway.app/api';
+const API_URL = process.env.REACT_APP_API_URL || 'https://codebyced.onrender.com/api';
 
 // Create axios instance with default config
 const api = axios.create({
@@ -21,4 +21,4 @@ api.interceptors.response.use(
   }
 );
 
-export default api;
+export default api

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,4 +1,4 @@
-export const apiBaseUrl = "https://codebyced-production.up.railway.app";
+export const apiBaseUrl = "https://codebyced.onrender.com";
 
 // Helper function to get the full API URL
-export const getApiUrl = (path) => `${apiBaseUrl}/api${path}`; 
+export const getApiUrl = (path) => `${apiBaseUrl}/api${path}`;

--- a/migrate-to-render.js
+++ b/migrate-to-render.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+
+// Backend environment file for Render
+const backendEnv = `PORT=5000
+MONGODB_URI=your-mongodb-uri
+NODE_ENV=production
+CLIENT_URL=https://codebyced.onrender.com
+ALLOWED_ORIGINS=https://codebyced.com,https://codebyced.onrender.com`;
+
+fs.writeFileSync(path.join(__dirname, 'backend', '.env.render.example'), backendEnv);
+console.log('Created backend/.env.render.example');
+
+// Frontend environment file for Render
+const frontendEnv = `REACT_APP_API_URL=https://codebyced.onrender.com/api`;
+fs.writeFileSync(path.join(__dirname, 'frontend', '.env.render.example'), frontendEnv);
+console.log('Created frontend/.env.render.example');
+


### PR DESCRIPTION
## Summary
- expose ALLOWED_ORIGINS and configure cors accordingly
- provide Render environment examples and migration helper script
- update frontend api endpoints to use Render backend
- streamline tools page to use api helper

## Testing
- `npm test` *(fails: Missing script)*
- `cd backend && npm test` *(fails: No tests found)*
- `cd frontend && npm test -- --watchAll=false` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_684f163542f08321a476380bafda60e3