### PR TITLE
Replace automations hero section with cover image

### DIFF
--- a/frontend/src/pages/AutomationsPage.jsx
+++ b/frontend/src/pages/AutomationsPage.jsx
@@ -31,17 +31,12 @@ const AutomationsPage = () => {
       </Helmet>
 
       <div className="max-w-6xl mx-auto px-4 py-10">
-        <section className="relative overflow-hidden rounded-3xl border border-cyan-400/20 bg-gray-900/75 backdrop-blur-xl p-8 md:p-12 shadow-2xl shadow-cyan-900/20 mb-12">
-          <div className="absolute -top-24 -right-16 w-80 h-80 bg-cyan-500/20 blur-3xl rounded-full" />
-          <div className="absolute -bottom-24 -left-16 w-80 h-80 bg-indigo-500/20 blur-3xl rounded-full" />
-          <div className="relative z-10">
-            <p className="inline-block text-xs uppercase tracking-[0.2em] text-cyan-200 mb-3">Automation Marketplace</p>
-            <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">Done-for-You AI Automation Systems</h1>
-            <p className="text-lg text-gray-200 max-w-3xl">
-              Deploy business-ready workflows powered by Make.com. Watch real demos, inspect the shared workflow logic,
-              and launch quickly with white-glove implementation.
-            </p>
-          </div>
+        <section className="mb-12">
+          <img
+            src="/automation_cover.png"
+            alt="Done-for-You AI Automation Systems"
+            className="w-full rounded-3xl"
+          />
         </section>
 
         {loading ? (


### PR DESCRIPTION
### Motivation
- Use the existing cover asset and simplify the Automations page hero by replacing verbose hero markup with the provided image at `frontend/public/automation_cover.png`.

### Description
- Updated `frontend/src/pages/AutomationsPage.jsx` to remove the original hero section and insert an `<img src="/automation_cover.png" />` element while preserving spacing and rounded styling.

### Testing
- Ran `npm --prefix frontend run build` which completed successfully and produced a production build. 
- Captured an automated Playwright screenshot of `http://127.0.0.1:3000/automations` which confirms the new cover image is rendered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69899d441d288321993a4cc73e4c820c)