### PR TITLE
Add Research Assistant automation entry

### DIFF
--- a/backend/data/automationSeed.js
+++ b/backend/data/automationSeed.js
@@ -9,6 +9,18 @@ const automationSeed = [
       'https://res.cloudinary.com/drssz6lnm/video/upload/v1770704461/Auto_Blog_tiztai.mp3',
     stripeCheckoutLink: 'https://buy.stripe.com/6oUcN6emwalpdE037Fawo0L',
   },
+
+  {
+    automationId: 'research-assistant',
+    name: 'Research Assistant',
+    description:
+      'This workflow uses an AI research assistant to analyze selected content, summarize key insights, and send results to your email. The output can also trigger follow-up automations, such as generating blog posts or other content automatically.',
+    makeSharedLink:
+      'https://us2.make.com/public/shared-scenario/ahIlSzt3vnq/research-assistant-and-zoho-mail',
+    stripeCheckoutLink: 'https://buy.stripe.com/8x24gA7Y83X17fC5fNawo0M',
+    demoAudioUrl:
+      'https://res.cloudinary.com/drssz6lnm/video/upload/v1771284710/reseaech_email_swq8ix.mp3',
+  },
 ];
 
 module.exports = { automationSeed };

--- a/frontend/src/services/automationsService.js
+++ b/frontend/src/services/automationsService.js
@@ -11,6 +11,18 @@ const fallbackAutomations = [
       'https://res.cloudinary.com/drssz6lnm/video/upload/v1770704461/Auto_Blog_tiztai.mp3',
     stripeCheckoutLink: 'https://buy.stripe.com/6oUcN6emwalpdE037Fawo0L',
   },
+
+  {
+    id: 'research-assistant',
+    name: 'Research Assistant',
+    description:
+      'This workflow uses an AI research assistant to analyze selected content, summarize key insights, and send results to your email. The output can also trigger follow-up automations, such as generating blog posts or other content automatically.',
+    makeSharedLink:
+      'https://us2.make.com/public/shared-scenario/ahIlSzt3vnq/research-assistant-and-zoho-mail',
+    stripeCheckoutLink: 'https://buy.stripe.com/8x24gA7Y83X17fC5fNawo0M',
+    demoAudioUrl:
+      'https://res.cloudinary.com/drssz6lnm/video/upload/v1771284710/reseaech_email_swq8ix.mp3',
+  },
 ];
 
 export const getAutomations = async () => {


### PR DESCRIPTION
### Motivation
- Expose a new "Research Assistant" automation so the app can present a prebuilt workflow for AI-driven content research and email delivery.
- Ensure the entry appears both from the API seed data and as a frontend fallback when the backend is unavailable.

### Description
- Added a new automation record with `automationId`/`id` set to `research-assistant` to `backend/data/automationSeed.js` containing `name`, `description`, `makeSharedLink`, `stripeCheckoutLink`, and `demoAudioUrl` fields.
- Added the same `Research Assistant` entry to the frontend fallback list in `frontend/src/services/automationsService.js` so UI consumers get consistent data when the API call fails.
- No changes to application logic or endpoints were required; this only updates hardcoded seed/fallback data.

### Testing
- Ran `node --check backend/data/automationSeed.js` and `node --check frontend/src/services/automationsService.js`, both succeeded.
- Ran `cd frontend && npm run build` to verify the frontend builds successfully, which completed without errors.
- Started the frontend dev server and captured a render of the `/automations` page via an automated Playwright script to validate the new entry appears, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993aca742c4832192b292edcb5b527b)