### PR TITLE
Fix BlogPostPage HTML rendering and preserve absolute cover image URLs

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.6.2",
+        "dompurify": "^3.3.1",
         "framer-motion": "^10.16.5",
         "mongodb": "^6.15.0",
         "react": "^18.3.0",
@@ -7064,6 +7065,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,10 +7,13 @@
     "node": ">=18"
   },
   "dependencies": {
+    "@stripe/stripe-js": "^3.4.0",
+    "@tailwindcss/typography": "^0.5.9",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.6.2",
+    "dompurify": "^3.3.1",
     "framer-motion": "^10.16.5",
     "mongodb": "^6.15.0",
     "react": "^18.3.0",
@@ -20,9 +23,7 @@
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.30.0",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4",
-    "@tailwindcss/typography": "^0.5.9",
-    "@stripe/stripe-js": "^3.4.0"
+    "web-vitals": "^2.1.4"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -32,18 +33,27 @@
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
-    "extends": ["react-app", "react-app/jest"]
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ]
   },
   "browserslist": {
-    "production": [">0.2%", "not dead", "not op_mini all"],
-    "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   },
   "devDependencies": {
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.31",
-    "tailwindcss": "^3.3.5",
-    "sitemap": "^8.0.0"
+    "sitemap": "^8.0.0",
+    "tailwindcss": "^3.3.5"
   }
 }
-
-

--- a/frontend/src/components/PostContent.jsx
+++ b/frontend/src/components/PostContent.jsx
@@ -1,0 +1,17 @@
+import React, { useMemo } from 'react';
+import DOMPurify from 'dompurify';
+
+const PostContent = ({ post }) => {
+  const sanitizedContent = useMemo(() => {
+    const html = post?.content ?? '';
+    return DOMPurify.sanitize(html);
+  }, [post?.content]);
+
+  if (!sanitizedContent) {
+    return <p>No content available.</p>;
+  }
+
+  return <div dangerouslySetInnerHTML={{ __html: sanitizedContent }} />;
+};
+
+export default PostContent;

--- a/frontend/src/pages/BlogPostPage.jsx
+++ b/frontend/src/pages/BlogPostPage.jsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { getBlogPost } from '../services/blogService';
-import ReactMarkdown from 'react-markdown';
 import { Helmet } from 'react-helmet';
 import PageLayout from '../components/PageLayout';
 import ShareButton from '../components/ShareButton';
+import PostContent from '../components/PostContent';
 
 const BlogPostPage = () => {
   const { id } = useParams();
@@ -39,6 +39,22 @@ const BlogPostPage = () => {
         
         // Extract the post data and ensure all fields are the correct type
         const postData = response.data;
+
+        const normalizeCoverImage = (coverImage) => {
+          if (!coverImage || typeof coverImage !== 'string') {
+            return '';
+          }
+
+          const trimmedCoverImage = coverImage.trim();
+
+          if (/^https?:\/\//i.test(trimmedCoverImage) || trimmedCoverImage.startsWith('//')) {
+            return trimmedCoverImage;
+          }
+
+          return trimmedCoverImage.startsWith('/')
+            ? trimmedCoverImage
+            : `/${trimmedCoverImage}`;
+        };
         
         // Debug logs
         console.log('Post data before sanitization:', postData);
@@ -52,9 +68,7 @@ const BlogPostPage = () => {
           excerpt: String(postData.excerpt || ''),
           date: postData.date || new Date().toISOString(),
           tags: Array.isArray(postData.tags) ? postData.tags.map(tag => String(tag)) : [],
-          coverImage: postData.coverImage ? 
-            (postData.coverImage.startsWith('/') ? postData.coverImage : `/${postData.coverImage}`) : 
-            '' // Ensure the path starts with a forward slash
+          coverImage: normalizeCoverImage(postData.coverImage)
         };
         
         // Debug logs
@@ -89,36 +103,6 @@ const BlogPostPage = () => {
     } catch (e) {
       console.error('Date formatting error:', e);
       return 'Unknown date';
-    }
-  };
-
-  // Simple content renderer fallback
-  const renderContentFallback = (content) => {
-    if (!content) return null;
-    try {
-      return content.split('\n').map((paragraph, idx) => (
-        paragraph.trim() ? <p key={idx} className="mb-4">{paragraph}</p> : null
-      )).filter(Boolean);
-    } catch (e) {
-      console.error('Content rendering fallback error:', e);
-      return <p>Content display error</p>;
-    }
-  };
-
-  const renderContent = (content) => {
-    if (!content || typeof content !== 'string') {
-      return <p>No content available</p>;
-    }
-
-    try {
-      return (
-        <div className="blog-content">
-          <ReactMarkdown>{content}</ReactMarkdown>
-        </div>
-      );
-    } catch (e) {
-      console.error('ReactMarkdown error:', e);
-      return renderContentFallback(content);
     }
   };
 
@@ -198,7 +182,7 @@ const BlogPostPage = () => {
             )}
 
             <div className="prose prose-lg prose-invert max-w-none">
-              {renderContent(post.content)}
+              <PostContent post={post} />
             </div>
 
             {post.references && post.references.length > 0 && (


### PR DESCRIPTION
### Motivation
- The blog detail page was rendering API-provided HTML as markdown/plain text so post body HTML did not render correctly.  
- Absolute cover image URLs were being rewritten as relative paths, causing cover images to appear in excerpts but disappear on the full post page.

### Description
- Use the existing safe HTML renderer by importing `PostContent` in `frontend/src/pages/BlogPostPage.jsx` and replace the old `react-markdown` rendering/fallback logic with `<PostContent post={post} />`.  
- Add a `normalizeCoverImage` helper in `BlogPostPage` that preserves absolute URLs (`http://`, `https://`, and protocol-relative `//`) while normalizing relative paths (prepends `/` when needed).  
- Add `DOMPurify` usage inside `frontend/src/components/PostContent.jsx` to sanitize HTML before injecting it via `dangerouslySetInnerHTML`.  
- Update `frontend/package.json` and `frontend/package-lock.json` to include the `dompurify` dependency.  
- Removed the old markdown/fallback helpers from `BlogPostPage` since they were not appropriate for the API HTML payloads.

### Testing
- Ran `npm install` in `frontend` to add `dompurify` which completed successfully.  
- Ran `npm run test -- --watchAll=false --passWithNoTests` and the test runner failed due to pre-existing Jest/ESM parsing issues in this repository (Axios ESM import handling), which is unrelated to these changes.  
- Started the frontend dev server with `npm start` and verified the app compiled successfully and rendered the blog list; a screenshot of the blog page was captured from the running dev server to validate UI rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69944003c8808321895e17a3c32bc1db)