### PR TITLE
Enhance blog sharing with rich social previews and new platforms

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -17,6 +17,7 @@ const toolsRoutes = require('./routes/toolsRoutes');
 const honorsRoutes = require('./routes/honorsRoutes');
 const servicesRoutes = require('./routes/servicesRoutes');
 const automationsRoutes = require('./routes/automationsRoutes');
+const shareRoutes = require('./routes/shareRoutes');
 
 const app = express();
 
@@ -88,6 +89,7 @@ app.use('/api/tools', toolsRoutes);
 app.use('/api/honors', honorsRoutes);
 app.use('/api/services', servicesRoutes);
 app.use('/api/automations', automationsRoutes);
+app.use('/share', shareRoutes);
 app.use('/api', searchRoutes);
 
 /* ---------- Health ---------- */

--- a/backend/routes/shareRoutes.js
+++ b/backend/routes/shareRoutes.js
@@ -1,0 +1,82 @@
+const express = require('express');
+const Blog = require('../models/Blog');
+
+const router = express.Router();
+
+const SITE_URL = (process.env.PUBLIC_SITE_URL || 'https://codebyced.com').replace(/\/$/, '');
+const DEFAULT_IMAGE = `${SITE_URL}/images/blog-header.jpg`;
+
+const escapeHtml = (value = '') => value
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&#39;');
+
+const toAbsoluteImageUrl = (coverImage) => {
+  if (!coverImage || typeof coverImage !== 'string') {
+    return DEFAULT_IMAGE;
+  }
+
+  const trimmed = coverImage.trim();
+  if (!trimmed) return DEFAULT_IMAGE;
+
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+  if (trimmed.startsWith('//')) return `https:${trimmed}`;
+  return `${SITE_URL}${trimmed.startsWith('/') ? '' : '/'}${trimmed}`;
+};
+
+router.get('/blog/:id', async (req, res) => {
+  try {
+    const post = await Blog.findById(req.params.id).select('title excerpt coverImage date');
+
+    if (!post) {
+      return res.status(404).send('Blog post not found');
+    }
+
+    const blogUrl = `${SITE_URL}/blog/${post._id}`;
+    const shareUrl = `${SITE_URL}/share/blog/${post._id}`;
+    const title = post.title || 'CodeByCed Blog';
+    const excerpt = post.excerpt || 'Read the latest posts on CodeByCed.';
+    const image = toAbsoluteImageUrl(post.coverImage);
+    const publishedAt = post.date ? new Date(post.date).toISOString() : '';
+
+    res.set('Content-Type', 'text/html; charset=utf-8');
+    return res.send(`<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>${escapeHtml(title)} | CodeByCed</title>
+  <meta name="description" content="${escapeHtml(excerpt)}" />
+  <link rel="canonical" href="${blogUrl}" />
+
+  <meta property="og:type" content="article" />
+  <meta property="og:site_name" content="CodeByCed" />
+  <meta property="og:url" content="${shareUrl}" />
+  <meta property="og:title" content="${escapeHtml(title)}" />
+  <meta property="og:description" content="${escapeHtml(excerpt)}" />
+  <meta property="og:image" content="${image}" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  ${publishedAt ? `<meta property="article:published_time" content="${publishedAt}" />` : ''}
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:site" content="@codebyced" />
+  <meta name="twitter:url" content="${shareUrl}" />
+  <meta name="twitter:title" content="${escapeHtml(title)}" />
+  <meta name="twitter:description" content="${escapeHtml(excerpt)}" />
+  <meta name="twitter:image" content="${image}" />
+
+  <meta http-equiv="refresh" content="0;url=${blogUrl}" />
+</head>
+<body>
+  <p>Redirecting to <a href="${blogUrl}">${escapeHtml(title)}</a>...</p>
+  <script>window.location.replace(${JSON.stringify(blogUrl)});</script>
+</body>
+</html>`);
+  } catch (error) {
+    return res.status(500).send('Unable to generate share preview');
+  }
+});
+
+module.exports = router;

--- a/frontend/src/components/ShareButton.jsx
+++ b/frontend/src/components/ShareButton.jsx
@@ -5,7 +5,6 @@ const ShareButton = ({ url, title, description, image }) => {
   const [copied, setCopied] = useState(false);
   const dropdownRef = useRef(null);
 
-  // Close dropdown when clicking outside
   useEffect(() => {
     const handleClickOutside = (event) => {
       if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
@@ -18,13 +17,13 @@ const ShareButton = ({ url, title, description, image }) => {
   }, []);
 
   const encodedUrl = encodeURIComponent(url);
-  const encodedTitle = encodeURIComponent(title);
-  const encodedDescription = encodeURIComponent(description || '');
+  const shareText = `${title}${description ? ` — ${description}` : ''}`;
 
   const shareUrls = {
-    twitter: `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodeURIComponent(`${title}${description ? ' — ' + description : ''}`)}`,
+    twitter: `https://twitter.com/intent/tweet?url=${encodedUrl}&text=${encodeURIComponent(shareText)}`,
     facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`,
-    linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}&title=${encodedTitle}&summary=${encodedDescription}`,
+    linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}`,
+    whatsapp: `https://wa.me/?text=${encodeURIComponent(`${shareText}\n${url}`)}`
   };
 
   const handleCopyLink = async () => {
@@ -41,24 +40,22 @@ const ShareButton = ({ url, title, description, image }) => {
   };
 
   const handleInstagram = async () => {
-    // Web Share API is the best way to reach Instagram on mobile
+    const caption = `${title}${description ? `\n\n${description}` : ''}${image ? `\n\nImage: ${image}` : ''}\n\n${url}`;
+
     if (navigator.share) {
       try {
         await navigator.share({
           title,
-          text: description ? `${title}\n\n${description}\n\n${url}` : `${title}\n\n${url}`,
+          text: caption,
           url,
         });
         setIsOpen(false);
       } catch (err) {
-        // User cancelled — not an error
         if (err.name !== 'AbortError') {
           console.error('Web Share failed:', err);
         }
       }
     } else {
-      // Desktop fallback: copy caption + link so user can paste into Instagram
-      const caption = `${title}${description ? `\n\n${description}` : ''}\n\n${url}`;
       try {
         await navigator.clipboard.writeText(caption);
         setCopied(true);
@@ -101,7 +98,6 @@ const ShareButton = ({ url, title, description, image }) => {
 
       {isOpen && (
         <div className="absolute right-0 mt-2 w-52 rounded-lg shadow-lg bg-gray-900 border border-gray-800 py-1 z-50">
-          {/* Twitter / X */}
           <button
             onClick={() => openShare('twitter')}
             className="w-full flex items-center px-4 py-2 text-gray-300 hover:bg-gray-800 hover:text-blue-400 transition-colors duration-200"
@@ -112,7 +108,6 @@ const ShareButton = ({ url, title, description, image }) => {
             Twitter / X
           </button>
 
-          {/* Facebook */}
           <button
             onClick={() => openShare('facebook')}
             className="w-full flex items-center px-4 py-2 text-gray-300 hover:bg-gray-800 hover:text-blue-400 transition-colors duration-200"
@@ -123,7 +118,6 @@ const ShareButton = ({ url, title, description, image }) => {
             Facebook
           </button>
 
-          {/* LinkedIn */}
           <button
             onClick={() => openShare('linkedin')}
             className="w-full flex items-center px-4 py-2 text-gray-300 hover:bg-gray-800 hover:text-blue-400 transition-colors duration-200"
@@ -134,7 +128,16 @@ const ShareButton = ({ url, title, description, image }) => {
             LinkedIn
           </button>
 
-          {/* Instagram */}
+          <button
+            onClick={() => openShare('whatsapp')}
+            className="w-full flex items-center px-4 py-2 text-gray-300 hover:bg-gray-800 hover:text-green-400 transition-colors duration-200"
+          >
+            <svg className="w-5 h-5 mr-3 flex-shrink-0" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M20.52 3.48A11.9 11.9 0 0012.04 0C5.4 0 .01 5.39.01 12.03c0 2.12.55 4.2 1.6 6.03L0 24l6.12-1.6a12 12 0 005.92 1.51h.01c6.64 0 12.03-5.39 12.03-12.03 0-3.21-1.25-6.23-3.56-8.4zM12.05 21.9a9.9 9.9 0 01-5.05-1.39l-.36-.21-3.63.95.97-3.54-.24-.36a9.9 9.9 0 01-1.54-5.32c0-5.48 4.46-9.94 9.95-9.94 2.65 0 5.14 1.03 7 2.9a9.86 9.86 0 012.91 7.02c0 5.48-4.46 9.94-9.95 9.94zm5.45-7.46c-.3-.15-1.78-.88-2.06-.98-.27-.1-.47-.15-.67.15s-.77.98-.95 1.18c-.17.2-.35.22-.64.08-.3-.15-1.25-.46-2.39-1.46a8.97 8.97 0 01-1.66-2.06c-.18-.3-.02-.46.13-.6.14-.14.3-.35.45-.52.15-.18.2-.3.3-.5.1-.2.05-.38-.03-.53-.08-.15-.67-1.62-.92-2.23-.24-.57-.48-.5-.67-.5h-.57c-.2 0-.53.07-.8.38-.28.3-1.05 1.03-1.05 2.5 0 1.48 1.08 2.91 1.24 3.11.15.2 2.13 3.25 5.16 4.56.72.31 1.28.5 1.72.64.72.23 1.37.2 1.88.12.58-.09 1.78-.73 2.03-1.43.25-.7.25-1.29.17-1.43-.07-.14-.27-.22-.57-.37z"/>
+            </svg>
+            WhatsApp
+          </button>
+
           <button
             onClick={handleInstagram}
             className="w-full flex items-center px-4 py-2 text-gray-300 hover:bg-gray-800 hover:text-pink-400 transition-colors duration-200"
@@ -145,10 +148,8 @@ const ShareButton = ({ url, title, description, image }) => {
             {copied ? 'Caption copied!' : 'Instagram'}
           </button>
 
-          {/* Divider */}
           <div className="my-1 border-t border-gray-800" />
 
-          {/* Copy Link */}
           <button
             onClick={handleCopyLink}
             className="w-full flex items-center px-4 py-2 text-gray-300 hover:bg-gray-800 hover:text-blue-400 transition-colors duration-200"

--- a/frontend/src/pages/BlogPostPage.jsx
+++ b/frontend/src/pages/BlogPostPage.jsx
@@ -107,6 +107,7 @@ const BlogPostPage = () => {
   };
 
   const postUrl = `https://codebyced.com/blog/${id}`;
+  const shareUrl = `https://codebyced.com/share/blog/${id}`;
   const ogImage = post?.coverImage
     ? post.coverImage.startsWith('http')
       ? post.coverImage
@@ -192,7 +193,7 @@ const BlogPostPage = () => {
                   </div>
                 </div>
                 <ShareButton
-                  url={postUrl}
+                  url={shareUrl}
                   title={post.title}
                   description={post.excerpt}
                   image={ogImage}

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -513,9 +513,10 @@ const HomePage = () => {
                   {/* Share Button */}
                   <div className="absolute top-2 right-2 z-10">
                     <ShareButton 
-                      url={`${window.location.origin}/blog/${post._id}`}
+                      url={`${window.location.origin}/share/blog/${post._id}`}
                       title={post.title}
                       description={post.excerpt}
+                      image={post.coverImage}
                     />
                   </div>
                   {post.coverImage && (


### PR DESCRIPTION
### Motivation
- Improve the user sharing experience so shared blog posts render as rich previews (image + excerpt + link) instead of plain URLs for social platforms.
- Ensure shared content pulls metadata dynamically from each blog post so previews remain accurate and visually engaging.
- Support additional common platforms (Instagram, WhatsApp) alongside Twitter/X, Facebook and LinkedIn to broaden share reach.

### Description
- Added a backend share endpoint at `GET /share/blog/:id` that reads a post's `title`, `excerpt`, `coverImage` and `date`, returns HTML with Open Graph and Twitter meta tags, and redirects humans to the canonical ` /blog/:id` URL (`backend/routes/shareRoutes.js`).
- Registered the new share route in the server so share links are served under `/share` (`backend/app.js`).
- Updated the `ShareButton` component to include WhatsApp and an improved Instagram flow that uses the Web Share API when available and copies a caption (title + excerpt + image reference + link) as a desktop fallback; Twitter/Facebook/LinkedIn behavior was preserved with cleaner payloads (`frontend/src/components/ShareButton.jsx`).
- Switched blog share links on the blog post page and homepage cards to point to `/share/blog/:id` and passed the post image to the share button so previews and copied captions include the featured image (`frontend/src/pages/BlogPostPage.jsx`, `frontend/src/pages/HomePage.jsx`).

### Testing
- Ran a production frontend build with `npm run -s build` in the `frontend/` folder and the build completed successfully.
- Verified the backend share route module loads without syntax/runtime import errors using `node -e "require('./backend/routes/shareRoutes'); console.log('shareRoutes ok')"`.
- Attempted an end-to-end screenshot via Playwright to validate rendered social-preview HTML, but the Chromium process crashed in this environment (Playwright SIGSEGV), so full rendering verification was not completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b756d51e0c8321b746fc5377532231)