### PR TITLE
Fix footer visibility by moving it inside PageLayout's scroll container

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -136,23 +136,6 @@ const Layout = ({ children }) => {
         {children}
       </main>
 
-      {/* Footer */}
-      <footer className="bg-gray-800 text-white py-6">
-        <div className="max-w-6xl mx-auto px-4">
-          <div className="flex flex-col md:flex-row justify-between items-center">
-            <div className="mb-4 md:mb-0">
-              <p>© {new Date().getFullYear()} CodeByCed. All rights reserved.</p>
-            </div>
-            {/* Hidden admin access */}
-            <Link to="/admin/login" className="text-gray-700 hover:text-gray-500 transition-colors" aria-label="Admin">
-              <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                <path fillRule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clipRule="evenodd" />
-              </svg>
-            </Link>
-          </div>
-        </div>
-      </footer>
-
       {/* ElevenLabs Convai Widget */}
       <ElevenLabsConvai />
     </div>

--- a/frontend/src/components/PageLayout.jsx
+++ b/frontend/src/components/PageLayout.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import NetworkBackground from './NetworkBackground';
 
 const PageLayout = ({ children }) => {
@@ -19,11 +20,28 @@ const PageLayout = ({ children }) => {
 
   return (
     <div className="fixed inset-0 w-screen overflow-y-auto bg-black">
-      <div className="relative min-h-screen pt-16">
+      <div className="relative min-h-screen pt-16 flex flex-col">
         <NetworkBackground />
-        <div className="relative z-10">
+        <div className="relative z-10 flex-1">
           {children}
         </div>
+
+        {/* Footer */}
+        <footer className="relative z-10 bg-gray-800 text-white py-6">
+          <div className="max-w-6xl mx-auto px-4">
+            <div className="flex flex-col md:flex-row justify-between items-center">
+              <div className="mb-4 md:mb-0">
+                <p>&copy; {new Date().getFullYear()} CodeByCed. All rights reserved.</p>
+              </div>
+              {/* Admin access */}
+              <Link to="/admin/login" className="text-gray-600 hover:text-gray-400 transition-colors" aria-label="Admin">
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                  <path fillRule="evenodd" d="M11.49 3.17c-.38-1.56-2.6-1.56-2.98 0a1.532 1.532 0 01-2.286.948c-1.372-.836-2.942.734-2.106 2.106.54.886.061 2.042-.947 2.287-1.561.379-1.561 2.6 0 2.978a1.532 1.532 0 01.947 2.287c-.836 1.372.734 2.942 2.106 2.106a1.532 1.532 0 012.287.947c.379 1.561 2.6 1.561 2.978 0a1.533 1.533 0 012.287-.947c1.372.836 2.942-.734 2.106-2.106a1.533 1.533 0 01.947-2.287c1.561-.379 1.561-2.6 0-2.978a1.532 1.532 0 01-.947-2.287c.836-1.372-.734-2.942-2.106-2.106a1.532 1.532 0 01-2.287-.947zM10 13a3 3 0 100-6 3 3 0 000 6z" clipRule="evenodd" />
+                </svg>
+              </Link>
+            </div>
+          </div>
+        </footer>
       </div>
     </div>
   );


### PR DESCRIPTION
The footer was hidden behind PageLayout's fixed full-screen overlay. Moved it into PageLayout where it's part of the scrollable content, and removed the duplicate from Layout.jsx. The gear icon for admin login is now visible at the bottom of every page.

https://claude.ai/code/session_015hwgSancQC97aGqSGHqzLu